### PR TITLE
Conexion/desconexion de clientes con websockets

### DIFF
--- a/src/main/java/es/urjc/code/daw/WebSockets/Managers/RegistrationManager.java
+++ b/src/main/java/es/urjc/code/daw/WebSockets/Managers/RegistrationManager.java
@@ -1,0 +1,43 @@
+package es.urjc.code.daw.WebSockets.Managers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class RegistrationManager extends BaseManager{
+
+    ConcurrentHashMap<WebSocketSession,String> usernamesMap= new ConcurrentHashMap<>();
+    
+    final ObjectMapper mapper = new ObjectMapper();
+    public RegistrationManager() {
+        associatedType="Registration";
+    }
+
+    @Override
+    public void connectionEstablished(WebSocketSession session) throws IOException {
+        
+    }
+
+    @Override
+    public void receiveMessage(WebSocketSession session, TextMessage message) throws Exception {
+        JsonNode node = mapper.readTree(message.getPayload());
+        String username= node.get("username").asText();
+        System.out.println("User connected with username: "+username);
+        usernamesMap.put(session,username);
+    }
+
+    @Override
+    public void connectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        
+        if(!usernamesMap.containsKey(session)) return;
+        
+        String username=usernamesMap.get(session);
+        System.out.println("User logged out with username: " + username);
+        usernamesMap.remove(session);
+    }
+}

--- a/src/main/java/es/urjc/code/daw/WebSockets/Managers/SessionsManager.java
+++ b/src/main/java/es/urjc/code/daw/WebSockets/Managers/SessionsManager.java
@@ -27,6 +27,7 @@ public class SessionsManager extends BaseManager{
     @Override
     public void connectionEstablished(WebSocketSession session) throws IOException {
         playersSessions.put(session.getId(), session);
+        System.out.println("User connected");
     }
 
     @Override
@@ -37,5 +38,6 @@ public class SessionsManager extends BaseManager{
     @Override
     public void connectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
         playersSessions.remove(session.getId());
+        System.out.println("User disconnected");
     }
 }

--- a/src/main/java/es/urjc/code/daw/WebSockets/WebsocketGatewayHandler.java
+++ b/src/main/java/es/urjc/code/daw/WebSockets/WebsocketGatewayHandler.java
@@ -47,8 +47,12 @@ public class WebsocketGatewayHandler extends TextWebSocketHandler {
 
         BaseManager chatManager = new ChatManager();
         this.managers.put(chatManager.getAssociatedType(),chatManager);
+        
         BaseManager playersVictoryManager = new PlayerVictoryManager();
         this.managers.put(playersVictoryManager.getAssociatedType(),playersVictoryManager);
+        
+        BaseManager registrationManager = new RegistrationManager();
+        this.managers.put(registrationManager.getAssociatedType(),registrationManager);
     }
 
     
@@ -63,7 +67,7 @@ public class WebsocketGatewayHandler extends TextWebSocketHandler {
         
 //        playersSessions.put(session.getId(),session);
         
-        System.out.println("Socket connected");
+//        System.out.println("Socket connected");
     }
 
     @Override

--- a/src/main/resources/static/js/scenes/HostOrJoin.js
+++ b/src/main/resources/static/js/scenes/HostOrJoin.js
@@ -13,7 +13,7 @@ let icons = {
     1: "ibbanIcon"
 }
 
-let isHost=false;
+let isHost = false;
 
 export class HostOrJoin extends Phaser.Scene {
     constructor() {
@@ -53,8 +53,8 @@ export class HostOrJoin extends Phaser.Scene {
         this.selectSprite.setVisible(false);
         this.selectSprite.setScale(.1);
 
-        this.hostScreen=this.add.image(250, 250, 'HostScreen').setOrigin(0).setDepth(1).setScale(1.3);
-        this.searchRoomScreen=this.add.image(763, 250, 'SearchRoomScreen').setOrigin(0).setDepth(1).setScale(1.3);
+        this.hostScreen = this.add.image(250, 250, 'HostScreen').setOrigin(0).setDepth(1).setScale(1.3);
+        this.searchRoomScreen = this.add.image(763, 250, 'SearchRoomScreen').setOrigin(0).setDepth(1).setScale(1.3);
 
 
         // this.add.text(width / 3,height * 0.1, 'Dual Interest', { fontSize: '40px', fill: '#000' }).setDepth(1);
@@ -63,7 +63,7 @@ export class HostOrJoin extends Phaser.Scene {
         this.joinButton = this.add.image(850, 262, 'JoinButton').setOrigin(0).setDepth(2).setScale(.8);
         this.readyButton = this.add.image(width / 2, height / 2 + 230, 'ReadyButton').setDepth(2).setScale(.8);
 
-        this.codeText = this.add.text(275, 350, " ", {fontFamily: 'ink-free-normal',fontSize:33});
+        this.codeText = this.add.text(275, 350, " ", {fontFamily: 'ink-free-normal', fontSize: 33});
         this.codeText.visible = false;
         this.codeText.setDepth(3);
 
@@ -76,7 +76,7 @@ export class HostOrJoin extends Phaser.Scene {
 
         this.hostButton.setInteractive();
         this.joinButton.setInteractive();
-        this.readyButton.alpha=.6
+        this.readyButton.alpha = .6
         // readyButton.setInteractive();
 
         this.hostButton.on('pointerdown', () => {
@@ -92,12 +92,12 @@ export class HostOrJoin extends Phaser.Scene {
             } else {
                 connection.send(JSON.stringify(hostInfo))
             }
-            isHost=true;
+            isHost = true;
             this.readyButton.setInteractive();
-            this.readyButton.alpha=1
+            this.readyButton.alpha = 1
             this.joinButton.disableInteractive();
-            this.joinButton.alpha=.6;
-            this.searchRoomScreen.alpha=.6;
+            this.joinButton.alpha = .6;
+            this.searchRoomScreen.alpha = .6;
             this.formUtil.hideElement("myText")
             this.hostButton.disableInteractive();
         })
@@ -108,12 +108,12 @@ export class HostOrJoin extends Phaser.Scene {
                 type2: "Join",
                 RoomCode: this.formUtil.getTextAreaValue("myText")
             }
-            if (codeRecieved === true){
+            if (codeRecieved === true) {
 
                 this.readyButton.setInteractive();
-                this.readyButton.alpha=1
-                this.hostScreen.alpha=.6
-                this.hostButton.alpha=.6
+                this.readyButton.alpha = 1
+                this.hostScreen.alpha = .6
+                this.hostButton.alpha = .6
                 this.joinButton.disableInteractive();
                 this.hostButton.disableInteractive();
                 this.formUtil.hideElement("myText")
@@ -149,9 +149,16 @@ export class HostOrJoin extends Phaser.Scene {
         var arrowDown = this.input.keyboard.on('keydown-' + 'DOWN', () => this.selectNextButton(1));
 
         var arrowUp = this.input.keyboard.on('keydown-' + 'UP', () => this.selectNextButton(-1));
-        
 
         this.setOnButtonInfoReceived();
+
+        // TEST
+
+        this.input.keyboard.on("keydown-ESC",this.goBackToMenu())
+
+        let goBackImage= this.add.image(height-200,100,"")
+        goBackImage.setInteractive()
+        goBackImage.on('pointerdown',()=>this.goBackToMenu())
     }
 
     sendMessage() {
@@ -260,41 +267,44 @@ export class HostOrJoin extends Phaser.Scene {
                 setRoomCode(code);
                 codeRecieved = true;
                 this.codeText.visible = true;
-                if (isHost){
+                if (isHost) {
                     this.codeText.setText("Your room code: " + code)
-                }else{
+                } else {
                     this.setJoinCodeText(code)
                 }
             }
-            if (message.type === "ConnectionClosed"){
+            if (message.type === "ConnectionClosed") {
                 console.log("external Connection closed reached")
                 // this.scene.manager.getScenes(true)[0].start("MenuSceneWS")
-                 this.scene.manager.getScenes(true)[0].scene.start("MenuSceneWS")
+                this.scene.manager.getScenes(true)[0].scene.start("MenuSceneWS")
                 // this.scene.manager.start("MenuSceneWS")
-                
+
             }
         })
     }
-    
-    setJoinCodeText(code){
-        
-        
-        this.codeText.x=785
-        this.codeText.setText("Joined in room: " + code )
+
+    setJoinCodeText(code) {
+
+
+        this.codeText.x = 785
+        this.codeText.setText("Joined in room: " + code)
 
         this.readyButton.setInteractive();
-        this.readyButton.alpha=1
-        this.hostScreen.alpha=.6
-        this.hostButton.alpha=.6
+        this.readyButton.alpha = 1
+        this.hostScreen.alpha = .6
+        this.hostButton.alpha = .6
         this.joinButton.disableInteractive();
         this.hostButton.disableInteractive();
         this.formUtil.hideElement("myText")
-        
+
     }
-    
-    loadScene(sceneKey){
+
+    loadScene(sceneKey) {
         this.scene.start(sceneKey)
         this.formUtil.hideElement("myText")
     }
-  
+
+    goBackToMenu() {
+        this.loadScene("MenuSceneWS")
+    }
 }

--- a/src/main/resources/static/js/scenes/MenuSceneWS.js
+++ b/src/main/resources/static/js/scenes/MenuSceneWS.js
@@ -5,6 +5,7 @@ import {ServerConnectionManager} from "../server/ServerConnectionManager.js";
 import {UserRegistration} from "../util/UserRegistration.js";
 import {ChatManager} from "../server/Websockets/ChatManager.js";
 import {getUser} from "../server/PlayersDataManager.js";
+import {getConnection} from "../server/Websockets/SocketIntilalizer.js";
 
 var music;
 const backgroundMusicKey = 'mainMenuMusic';
@@ -413,32 +414,55 @@ export class MenuSceneWS extends Phaser.Scene {
         let username = this.formUtil.getTextAreaValue("myUser");
         let password = this.formUtil.getTextAreaValue("myPass");
         let confirmPassword = this.formUtil.getTextAreaValue("myPass");
+        
         this.userRegistration.trySignUp(username, password, confirmPassword,
             (user) => this.Registered(user), () => this.loginErrorText.text = "Username " + username + " already taken")
+        
     }
 
     Registered(user) {
+        
+        
+        
         if (user !== null) {
             this.user = user;
             // console.log("username obtained " + user['username'])
-            this.enableChatButton();
-            this.enableOnlineGameButton()
+            
             ServerConnectionManager.setClientId(user['username'])
-            ServerConnectionManager.ConnectUser();
-            this.xButton2.x = 240;
-            this.setPlayerInformation();
-            if (this.loginVisible === true) {
-                this.disableResgisterScreen()
-                this.xButton2.setVisible(0);
-                this.loginVisible = false;
-                this.gamesVisible = true;
+            
+            // New implementation uses WebSocket to check connections
+            // ServerConnectionManager.ConnectUser();
+            
+            this.displayPlayerWindow()
+            
+            let connection = getConnection();
+            let registrationMsg = {
+                type: "Registration",
+                username:this.user.username
             }
+            connection.send(JSON.stringify(registrationMsg))
 
         } else {
             // console.log("User undefined")
         }
     }
+    
+    
+    displayPlayerWindow(){
+        this.enableChatButton();
+        this.enableOnlineGameButton()
+        
 
+        this.xButton2.x = 240;
+        this.setPlayerInformation();
+
+        if (this.loginVisible === true) {
+            this.disableResgisterScreen()
+            this.xButton2.setVisible(0);
+            this.loginVisible = false;
+            this.gamesVisible = true;
+        }
+    }
     enableOnlineGameButton() {
         this.onlineGame.alpha = 1.0;
         this.buttons.splice(1, 0, this.onlineGame);
@@ -655,13 +679,16 @@ export class MenuSceneWS extends Phaser.Scene {
             // this.user=getUser()
             // this.loginButton.setVisible(true)
             // this.loginButton.setTexture(icons[this.user['iconIndex']])
+            this.user=getUser()
             let currentUser={
-                username:getUser().username,
-                password:getUser().password
+                username:this.user.username,
+                password:this.user.password
             }
             //
             // this.Registered(user)
-            this.userRegistration.logIn(currentUser.username, currentUser.password, (user) => this.Registered(user))
+            // this.userRegistration.logIn(currentUser.username, currentUser.password, (user) => this.Registered(user))
+            this.displayPlayerWindow()
+            //TODO-> obtener victorias de nuevo
         }
     }
 


### PR DESCRIPTION
Se ha cambiado la implementacion de las conexiones y registros de usuario a websockets.

Al volver al menu principal, se muestra la informacion del usuario.

TODO:
* actualizar **solo** las victorias al volver al menu.
* Decidir como mostrar la informacion del usuario cuando se pierde la conexión del servidor.